### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### Changes Description
+_Please include a summary of the changes..._
+
+### Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### Changes Details
+_Add more context to the describe the change. Be very detail while listing the changes. Please also include relevant motivation. 
+List any dependencies that are required for this change_
+
+### How Has This Been Tested?
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
+Please also list any relevant details for your test configuration_
+
+### Checklist
+- [ ] I have performed a self-review of my code
+- [ ] If it is a core feature, I have added thorough tests.
+- [ ] Do we need to implement analytics?
+- [ ] Will this be part of a product update? If yes, please write one phrase about this update


### PR DESCRIPTION
Pull request templates to allow the JAJA! team to have a default text when they create a pull request on GitHub. It is quite useful to make sure to follow a standard process for every pull request and to have a to-do list for the author to check before requesting a review.