### PR TITLE
fix(wavelength): correcting fontawesome and js/scripts calls

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -41,7 +41,7 @@ Team page
 
     <!-- Adding Font Awesome icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.14.4/css/all.css">
+    <link rel="stylesheet" xmlns="https://use.fontawesome.com/releases/v5.14.4/css/all.css">
   </head>
     {% block css %}{% endblock %}
 
@@ -72,9 +72,9 @@ Team page
 
           {% block body %}{% endblock %}
     <!-- JavaScripts simple tags -->
-    <script src="..\static\js\bootstrap.bundle.min.js"></script>
-    <script src="..\static\js\prism.js" data-manual></script>  
-    <script src="..\static\js\bootstrap.bundle.min.js"></script>
+    <script xmlns="..\static\js\bootstrap.bundle.min.js"></script>
+    <script xmlns="..\static\js\prism.js" data-manual></script>  
+    <script xmlns="..\static\js\bootstrap.bundle.min.js"></script>
     
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/js/fontawesome.min.js" integrity="sha512-vF2g7ozd8M2AA8re3eCrfJT2vvrOmIbW9JhodInQHN5Xjg6ec6nJpMJQcwuXm+aOhQze+CrM2rFQLftMtQA+bA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Solving change href for xmlns

### Changes Description
Fontawesome and java scripts couldn't be found

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes Details
The HTTP response content representing a HTML document as text/xml instead of text/html and the parsed XML tree doesn't have any [XML-stylesheet](http://www.w3.org/TR/xml-stylesheet/). In other words, the web browser parsed the retrieved HTTP response content as XML instead of as HTML due to a missing or incorrect HTTP response content type.

### How Has This Been Tested?
Navigating through all pages

### Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
