### PR TITLE
fix(wavelength): remove 'conn_age_max' from database settings.py

### DIFF
--- a/wavelength/settings.py
+++ b/wavelength/settings.py
@@ -119,7 +119,7 @@ DATABASES = {
 # Change 'default' database configuration with $DATABASE_URL.
 DATABASE_URL = os.environ.get('DATABASE_URL')
 DATABASES['default'].update(dj_database_url.config(
-    default=DATABASE_URL, conn_max_age=500, ssl_require=True
+    default=DATABASE_URL, ssl_require=True
 ))
 
 # Redis URL


### PR DESCRIPTION
### Changes Description
Remove 'conn_age_max' from database settings to prevent maxing out heroku postgresql connection utilization

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes Details

### How Has This Been Tested?
Tested in external heroku sandbox

### Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
